### PR TITLE
Deployment bugfix

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta http-equiv="refresh" content="0; url=/src/index.html">
+</head>
+<body>
+</body>
+</html>

--- a/404.html
+++ b/404.html
@@ -1,8 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta http-equiv="refresh" content="0; url=/src/index.html">
-</head>
-<body>
-</body>
-</html>

--- a/index.html
+++ b/index.html
@@ -4,11 +4,11 @@
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Retro Terminal</title>
-		<link rel="stylesheet" href="css/styles.css" />
-		<link rel="stylesheet" href="css/typography.css" />
-		<link rel="stylesheet" href="css/colors.css" />
-		<link rel="stylesheet" href="menu/menu.css" />
-		<link rel="stylesheet" href="password/password.css" />
+		<link rel="stylesheet" href="src/css/styles.css" />
+		<link rel="stylesheet" href="src/css/typography.css" />
+		<link rel="stylesheet" href="src/css/colors.css" />
+		<link rel="stylesheet" href="src/menu/menu.css" />
+		<link rel="stylesheet" href="src/password/password.css" />
 		<link
 			href="https://fonts.googleapis.com/css2?family=VT323&display=swap"
 			rel="stylesheet"
@@ -18,9 +18,9 @@
 		<div id="app"></div>
 		<audio
 			id="success-sound"
-			src="../assets/sound/success_bell-6776.mp3"
+			src="assets/sound/success_bell-6776.mp3"
 			preload="auto"
 		></audio>
-		<script type="module" src="main.js"></script>
+		<script type="module" src="src/main.js"></script>
 	</body>
 </html>

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1,3 +1,15 @@
+.terminal-content {
+	font-size: 24px;
+	line-height: 1.5;
+	text-shadow: 0 0 5px #00ff00;
+}
+
+.prompt {
+	margin-bottom: 20px;
+}
+
+/* Utility classes */
+
 .p-0 {
 	padding: 0;
 }
@@ -50,12 +62,6 @@
 	gap: 10px;
 }
 
-.terminal-content {
-	font-size: 24px;
-	line-height: 1.5;
-	text-shadow: 0 0 5px #00ff00;
-}
-
-.prompt {
-	margin-bottom: 20px;
+.pointer-events-none {
+	pointer-events: none;
 }

--- a/src/password/password.html
+++ b/src/password/password.html
@@ -9,24 +9,24 @@
 		</div>
 		<div class="keypad d-flex flex-column">
 			<div class="d-flex gap-10-px">
-				<div class="key d-flex align-items-center justify-content-center cursor-default" data-value="1">1</div>
-				<div class="key d-flex align-items-center justify-content-center cursor-default" data-value="2">2</div>
-				<div class="key d-flex align-items-center justify-content-center cursor-default" data-value="3">3</div>
+				<div class="key d-flex align-items-center justify-content-center cursor-default pointer-events-none" data-value="1">1</div>
+				<div class="key d-flex align-items-center justify-content-center cursor-default pointer-events-none" data-value="2">2</div>
+				<div class="key d-flex align-items-center justify-content-center cursor-default pointer-events-none" data-value="3">3</div>
 			</div>
 			<div class="d-flex gap-10-px">
-				<div class="key d-flex align-items-center justify-content-center cursor-default" data-value="4">4</div>
-				<div class="key d-flex align-items-center justify-content-center cursor-default" data-value="5">5</div>
-				<div class="key d-flex align-items-center justify-content-center cursor-default" data-value="6">6</div>
+				<div class="key d-flex align-items-center justify-content-center cursor-default pointer-events-none" data-value="4">4</div>
+				<div class="key d-flex align-items-center justify-content-center cursor-default pointer-events-none" data-value="5">5</div>
+				<div class="key d-flex align-items-center justify-content-center cursor-default pointer-events-none" data-value="6">6</div>
 			</div>
 			<div class="d-flex gap-10-px">
-				<div class="key d-flex align-items-center justify-content-center cursor-default" data-value="7">7</div>
-				<div class="key d-flex align-items-center justify-content-center cursor-default" data-value="8">8</div>
-				<div class="key d-flex align-items-center justify-content-center cursor-default" data-value="9">9</div>
+				<div class="key d-flex align-items-center justify-content-center cursor-default pointer-events-none" data-value="7">7</div>
+				<div class="key d-flex align-items-center justify-content-center cursor-default pointer-events-none" data-value="8">8</div>
+				<div class="key d-flex align-items-center justify-content-center cursor-default pointer-events-none" data-value="9">9</div>
 			</div>
 			<div class="d-flex gap-10-px">
-				<div class="key d-flex align-items-center justify-content-center cursor-default" data-value="clear">CLR</div>
-				<div class="key d-flex align-items-center justify-content-center cursor-default" data-value="0">0</div>
-				<div class="key d-flex align-items-center justify-content-center cursor-default" data-value="enter">ENT</div>
+				<div class="key d-flex align-items-center justify-content-center cursor-default pointer-events-none" data-value="clear">CLR</div>
+				<div class="key d-flex align-items-center justify-content-center cursor-default pointer-events-none" data-value="0">0</div>
+				<div class="key d-flex align-items-center justify-content-center cursor-default pointer-events-none" data-value="enter">ENT</div>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
This pull request includes changes to the file structure and CSS classes for the Retro Terminal project. The most important changes include renaming the `index.html` file, updating file paths, and adding and modifying CSS classes.

File structure and path updates:

* [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L7-R11): Renamed from `src/index.html` and updated file paths for CSS and JavaScript files. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L7-R11) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L21-R24)

CSS class additions and modifications:

* [`src/css/styles.css`](diffhunk://#diff-506553736ec2a7007edf02fc6f203dc94a6f62054042f9148957f96270a7db22R1-R12): Added `.terminal-content` and `.prompt` classes, and introduced utility class `.pointer-events-none`.
* [`src/css/styles.css`](diffhunk://#diff-506553736ec2a7007edf02fc6f203dc94a6f62054042f9148957f96270a7db22L53-R66): Removed `.terminal-content` and `.prompt` classes, and added `.pointer-events-none` class.
* [`src/password/password.html`](diffhunk://#diff-1f83a502fb5bd1641797c10911164c309d1d0c3884e4972e40b34e9e0faf2e0fL12-R29): Added `pointer-events-none` class to keypad elements to disable pointer events.